### PR TITLE
ruamel.yaml.jinja2 0.2.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml.jinja2" %}
-{% set version = "0.2.4" %}
+{% set version = "0.2.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,32 +7,33 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c8e1d4e6d638c519a548be754639cbfb06560f9f0a95922435bdb4cf64816801
+  sha256: 8449be29d9a157fa92d1648adc161d718e469f0d38a6b21e0eabb76fd5b3e663
 
 build:
-  number: 1
+  number: 0
+  skip: True  # [py<37]
   script: 
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . -vv --no-deps
     - {{ PYTHON }} {{ RECIPE_DIR }}/rm_broken_file.py
-  noarch: python
 
 requirements:
   host:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
     - ruamel.yaml >=0.15.10
 
 test:
+  imports:
+    - ruamel.yaml.jinja2
   requires:
     - pip
   commands:
-    - python -m pip check
+    - pip check
     - python -c "from ruamel.yaml import YAML; YAML(typ='jinja2')"
-  imports:
-    - ruamel.yaml.jinja2
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml-jinja2/
@@ -44,6 +45,8 @@ about:
     jinja2 templates for YAML files can normally not be loaded as YAML before
     rendering. This plugin allows pre and post-processing based on the
     round-trip processor.
+  dev_url: https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/default/tree/
+  doc_url: https://sourceforge.net/projects/ruamel-yaml-jinja2/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The upstream: https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/0.2.7/tree/
License: https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/0.2.7/tree/LICENSE
Requirements: https://sourceforge.net/p/ruamel-yaml-jinja2/code/ci/0.2.7/tree/setup.py


Actions:

- Skip py<37

- Reset build number to 0

- Add wheel

- Add --no-deps to script

- Fix pip check

- Add dev and doc urls